### PR TITLE
feat: Integrate MCP server configuration for external tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,75 @@ Here's a list of all the providers and their default models:
 export GOOGLE_GENERATIVE_AI_API_KEY="your-gemini-api-key-here"
 ```
 
+### MCP Server Integration (External Tools)
+
+The Codex CLI can be extended with additional tools by connecting to external servers that implement the Model Context Protocol (MCP). This allows the agent to leverage custom or third-party functionalities.
+
+To configure MCP servers, add an `mcpServers` array to your `~/.codex/config.yaml` (or `config.json`) file.
+
+**Configuration Example (YAML):**
+
+```yaml
+# ~/.codex/config.yaml
+# ... other configurations ...
+mcpServers:
+  - name: "MyCalculatorServer"  # A user-friendly name for this server
+    url: "http://localhost:3001/mcp" # The full URL to the MCP server's endpoint
+    enabled: true                 # Optional: true by default. Set to false to disable.
+  - name: "AnotherToolsAPI"
+    url: "https://mcp.example.com/api"
+    # 'enabled' defaults to true if omitted
+    # auth: # Optional: For authentication mechanisms
+    #   type: "apiKey" 
+    #   key: "your-secret-api-key" 
+    # # Or for OAuth:
+    # # auth:
+    # #   type: "oauth"
+    # #   clientId: "your-client-id"
+    # #   clientSecret: "your-client-secret"
+```
+
+**JSON Equivalent:**
+For `config.json`, the structure would be:
+```json
+{
+  // ... other configurations ...
+  "mcpServers": [
+    {
+      "name": "MyCalculatorServer",
+      "url": "http://localhost:3001/mcp",
+      "enabled": true
+    },
+    {
+      "name": "AnotherToolsAPI",
+      "url": "https://mcp.example.com/api"
+      // "auth": { "type": "apiKey", "key": "your-secret-api-key" }
+    }
+  ]
+}
+```
+
+**Configuration Fields:**
+
+*   `name` (string, required): A unique, user-friendly name for the server. This name is used internally and helps in identifying tools from different servers.
+*   `url` (string, required): The complete URL to the MCP server's endpoint (e.g., `http://my-mcp-server.com/mcp_endpoint`).
+*   `enabled` (boolean, optional): Defaults to `true`. If set to `false`, this server configuration will be ignored, and its tools will not be loaded.
+*   `auth` (object, optional): Defines authentication details for the server. The `McpClient` currently does not implement special handling for these `auth` types beyond what might be included in the `url` itself (e.g., token in query parameter). The structure is defined for future compatibility or for servers that can interpret these fields if passed through.
+    *   `type`: Can be `"apiKey"` or `"oauth"`.
+    *   For `apiKey`: `key` (string) holding the API key.
+    *   For `oauth`: `clientId` (string) and `clientSecret` (string).
+
+**Tool Usage:**
+
+Tools from all enabled MCP servers are automatically discovered by the agent when it starts. These tools are then made available to the language model.
+
+To prevent naming conflicts and provide clarity, tools from MCP servers are prefixed with `mcp_`, followed by the server `name` you defined in the configuration, and then the actual tool name as provided by the server.
+
+*   **Naming Convention:** `mcp_<serverName>_<actualToolName>`
+*   **Example:** If a server named `MyCalculatorServer` provides a tool called `calculateSum`, the language model will see and use this tool as `mcp_MyCalculatorServer_calculateSum`.
+
+The Codex CLI agent handles the routing of these tool calls to the appropriate MCP server based on this naming convention.
+
 ---
 
 ## FAQ

--- a/codex-cli/package-lock.json
+++ b/codex-cli/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "open-codex",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-codex",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "license": "Apache-2.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
+        "@modelcontextprotocol/sdk": "*",
         "chalk": "^5.2.0",
         "diff": "^7.0.0",
         "dotenv": "^16.1.4",
@@ -701,6 +702,27 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.0.tgz",
+      "integrity": "sha512-m//7RlINx1F3sz3KqwY1WWzVgTcYX52HYk4bJ1hkBXV3zccAEth+jRvG8DBRrdaQuRsPAJOx2MH3zaHNCKL7Zg==",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1470,6 +1492,18 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -1519,8 +1553,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1842,6 +1874,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/boxen": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
@@ -1913,6 +1964,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1956,7 +2015,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -2300,12 +2358,59 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/create-require": {
@@ -2318,8 +2423,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2333,17 +2436,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -2530,6 +2629,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/diff": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
@@ -2587,6 +2694,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
     "node_modules/emoji-regex": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
@@ -2596,6 +2708,14 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -2829,6 +2949,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3311,12 +3436,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
+      "integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expect-type": {
@@ -3326,6 +3478,61 @@
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3364,9 +3571,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -3443,6 +3648,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/find-up": {
@@ -3547,6 +3768,22 @@
       },
       "engines": {
         "node": ">= 12.20"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs.realpath": {
@@ -3897,12 +4134,38 @@
         "node": "*"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -3986,9 +4249,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ink": {
       "version": "5.2.0",
@@ -4077,6 +4338,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4363,6 +4632,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4585,9 +4859,7 @@
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4741,10 +5013,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
       "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "engines": {
         "node": ">=18"
       },
@@ -4772,6 +5063,25 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -4844,6 +5154,14 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -4927,7 +5245,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5029,12 +5346,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5210,6 +5536,14 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/patch-console": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
@@ -5242,8 +5576,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5253,6 +5585,14 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -5306,6 +5646,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5381,13 +5729,38 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -5409,6 +5782,28 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -5603,6 +5998,21 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
@@ -5656,6 +6066,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -5689,6 +6118,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -5707,6 +6141,41 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/set-function-length": {
@@ -5755,12 +6224,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -5772,8 +6244,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5793,7 +6263,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -5812,7 +6281,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -5828,7 +6296,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -5846,7 +6313,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -5954,6 +6420,14 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -6267,6 +6741,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/token-types": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
@@ -6395,6 +6877,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -6526,12 +7021,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -6553,6 +7054,14 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "6.2.6",
@@ -6920,9 +7429,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
       "version": "8.18.1",
@@ -7034,10 +7541,16 @@
       "version": "3.24.2",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
-      "optional": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -43,7 +43,8 @@
     "react": "^18.2.0",
     "shell-quote": "^1.8.2",
     "to-rotated": "^1.0.0",
-    "use-interval": "1.4.0"
+    "use-interval": "1.4.0",
+    "@modelcontextprotocol/sdk": "*"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -428,6 +428,7 @@ async function runQuietMode({
     onReset: () => {
       /* intentionally ignored in quiet mode */
     },
+    mcpServers: config.mcpServers, // Added MCP servers
   });
 
   const inputItem = await createInputItem(prompt, imagePaths);

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -104,6 +104,7 @@ export default function TerminalChat({
       config,
       instructions: config.instructions,
       approvalPolicy,
+      mcpServers: config.mcpServers, // Added MCP servers
       onReset: () => setPrevItems([]),
       onItem: (item) => {
         log(`onItem: ${JSON.stringify(item)}`);

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -152,12 +152,13 @@ export type StoredConfig = {
   approvalMode?: AutoApprovalMode;
   fullAutoErrorMode?: FullAutoErrorMode;
   memory?: MemoryConfig;
+  mcpServers?: McpServerConfig[];
 };
 
 // Minimal config written on first run.  An *empty* model string ensures that
 // we always fall back to DEFAULT_MODEL on load, so updates to the default keep
 // propagating to existing users until they explicitly set a model.
-export const EMPTY_STORED_CONFIG: StoredConfig = { model: "" };
+export const EMPTY_STORED_CONFIG: StoredConfig = { model: "", mcpServers: [] };
 
 // Pre‑stringified JSON variant so we don’t stringify repeatedly.
 const EMPTY_CONFIG_JSON = JSON.stringify(EMPTY_STORED_CONFIG, null, 2) + "\n";
@@ -165,6 +166,13 @@ const EMPTY_CONFIG_JSON = JSON.stringify(EMPTY_STORED_CONFIG, null, 2) + "\n";
 export type MemoryConfig = {
   enabled: boolean;
 };
+
+export interface McpServerConfig {
+  name: string;
+  url: string;
+  enabled?: boolean;
+  auth?: { type: "apiKey"; key: string } | { type: "oauth"; clientId: string; clientSecret: string };
+}
 
 // Represents full runtime config, including loaded instructions.
 export type AppConfig = {
@@ -176,6 +184,7 @@ export type AppConfig = {
   approvalMode?: AutoApprovalMode;
   fullAutoErrorMode?: FullAutoErrorMode;
   memory?: MemoryConfig;
+  mcpServers?: McpServerConfig[];
 };
 
 // ---------------------------------------------------------------------------
@@ -460,6 +469,10 @@ export const loadConfig = (
   // fixtures) that don't include a "memory" section.
   if (storedConfig.memory !== undefined) {
     config.memory = storedConfig.memory;
+  }
+
+  if (storedConfig.mcpServers !== undefined) {
+    config.mcpServers = storedConfig.mcpServers;
   }
 
   if (storedConfig.fullAutoErrorMode) {

--- a/codex-cli/src/utils/mcp-client.ts
+++ b/codex-cli/src/utils/mcp-client.ts
@@ -1,0 +1,163 @@
+import { Client, StreamableHTTPClientTransport, ToolDefinition } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpServerConfig } from "./config.js";
+import { log } from "./agent/log.js";
+
+export class McpClient {
+  private serverConfig: McpServerConfig;
+  private transport: StreamableHTTPClientTransport | null = null;
+  private client: Client | null = null;
+  private isConnected: boolean = false;
+
+  constructor(serverConfig: McpServerConfig) {
+    this.serverConfig = serverConfig;
+    log(`[McpClient] Initializing for server: ${this.serverConfig.name} at ${this.serverConfig.url}`);
+
+    if (!this.serverConfig.url) {
+      const errorMsg = `[McpClient] Server URL is not defined for ${this.serverConfig.name}. Cannot initialize.`;
+      log(errorMsg);
+      // Throw an error or handle this state appropriately, as client cannot function.
+      // For now, we'll let it be, but connect() will fail.
+      return;
+    }
+
+    // Initialization of transport and client is deferred to an init() method or before connect()
+    // to handle potential errors more gracefully, especially if URL is invalid.
+  }
+
+  private async ensureClientInitialized(): Promise<void> {
+    if (this.client && this.transport) {
+      return; // Already initialized
+    }
+
+    if (!this.serverConfig.url) {
+      const errorMsg = `[McpClient] Server URL is not defined for ${this.serverConfig.name}. Cannot initialize client.`;
+      log(errorMsg);
+      throw new Error(errorMsg);
+    }
+
+    try {
+      log(`[McpClient] Lazily initializing transport and client for ${this.serverConfig.name}`);
+      this.transport = new StreamableHTTPClientTransport(new URL(this.serverConfig.url));
+      // TODO: Use actual CLI version if available dynamically
+      this.client = new Client({ name: "codex-cli-mcp-client", version: "1.0.0" }); 
+      log(`[McpClient] Client and transport initialized for ${this.serverConfig.name}.`);
+
+      this.client.on('error', (error: Error) => {
+        log(`[McpClient] Connection error on ${this.serverConfig.name}: ${error.message}`);
+        this.isConnected = false;
+        // Potentially attempt to reconnect or notify user
+      });
+
+    } catch (error: any) {
+      const errorMsg = `[McpClient] Error during lazy initialization for ${this.serverConfig.name}: ${error.message}`;
+      log(errorMsg);
+      this.client = null; // Ensure client is null if init fails
+      this.transport = null;
+      throw new Error(errorMsg); // Re-throw to signal failure
+    }
+  }
+
+  public async connect(): Promise<void> {
+    if (this.isConnected) {
+      log(`[McpClient] Already connected to ${this.serverConfig.name}.`);
+      return;
+    }
+
+    try {
+      await this.ensureClientInitialized(); // Initialize client and transport if not already done
+      
+      if (!this.client || !this.transport) { // Check again after initialization attempt
+          const errorMsg = `[McpClient] Client or transport failed to initialize for ${this.serverConfig.name}. Cannot connect.`;
+          log(errorMsg);
+          throw new Error(errorMsg);
+      }
+
+      log(`[McpClient] Connecting to ${this.serverConfig.name} at ${this.serverConfig.url}...`);
+      await this.client.connect(this.transport);
+      this.isConnected = true;
+      log(`[McpClient] Successfully connected to ${this.serverConfig.name}.`);
+    } catch (error: any) {
+      this.isConnected = false;
+      // Error already logged by ensureClientInitialized if it failed there
+      if (!error.message.includes("lazy initialization")) { // Avoid double logging
+          const errorMsg = `[McpClient] Failed to connect to ${this.serverConfig.name}: ${error.message}`;
+          log(errorMsg);
+      }
+      throw error; // Re-throw to signal connection failure
+    }
+  }
+
+  public async listTools(): Promise<ToolDefinition[]> {
+    await this.ensureClientInitialized();
+    if (!this.isConnected || !this.client) {
+      const errorMsg = `[McpClient] Not connected to ${this.serverConfig.name}. Call connect() first.`;
+      log(errorMsg);
+      throw new Error(errorMsg);
+    }
+
+    try {
+      log(`[McpClient] Listing tools from ${this.serverConfig.name}...`);
+      const tools = await this.client.listTools();
+      log(`[McpClient] Found ${tools.length} tools on ${this.serverConfig.name}.`);
+      return tools;
+    } catch (error: any) {
+      const errorMsg = `[McpClient] Failed to list tools from ${this.serverConfig.name}: ${error.message}`;
+      log(errorMsg);
+      throw new Error(errorMsg);
+    }
+  }
+
+  public async callTool(toolName: string, args: any): Promise<any> {
+    await this.ensureClientInitialized();
+    if (!this.isConnected || !this.client) {
+      const errorMsg = `[McpClient] Not connected to ${this.serverConfig.name}. Call connect() first.`;
+      log(errorMsg);
+      throw new Error(errorMsg);
+    }
+
+    try {
+      log(`[McpClient] Calling tool "${toolName}" on ${this.serverConfig.name} with args: ${JSON.stringify(args)}`);
+      const result = await this.client.callTool({ name: toolName, arguments: args });
+      log(`[McpClient] Tool "${toolName}" on ${this.serverConfig.name} executed successfully.`);
+      return result;
+    } catch (error: any) {
+      const errorMsg = `[McpClient] Failed to call tool "${toolName}" on ${this.serverConfig.name}: ${error.message}`;
+      log(errorMsg);
+      throw new Error(errorMsg);
+    }
+  }
+
+  public async disconnect(): Promise<void> {
+    if (!this.client) { // If client was never initialized (e.g. bad URL from start)
+        log(`[McpClient] Client for ${this.serverConfig.name} was not initialized. Nothing to disconnect.`);
+        this.isConnected = false; // Ensure state is consistent
+        return;
+    }
+      
+    if (!this.isConnected) {
+      log(`[McpClient] Already disconnected from ${this.serverConfig.name}.`);
+      return;
+    }
+
+    try {
+      log(`[McpClient] Disconnecting from ${this.serverConfig.name}...`);
+      await this.client.disconnect();
+      this.isConnected = false;
+      log(`[McpClient] Successfully disconnected from ${this.serverConfig.name}.`);
+    } catch (error: any) {
+      this.isConnected = false; 
+      const errorMsg = `[McpClient] Failed to disconnect from ${this.serverConfig.name}: ${error.message}`;
+      log(errorMsg);
+      throw new Error(errorMsg);
+    }
+  }
+
+  public getIsConnected(): boolean {
+    return this.isConnected;
+  }
+
+  // Optional: Method to get server name, useful for managing multiple clients
+  public getServerName(): string {
+    return this.serverConfig.name;
+  }
+}

--- a/codex-cli/tests/agent-mcp.test.ts
+++ b/codex-cli/tests/agent-mcp.test.ts
@@ -1,0 +1,336 @@
+import { AgentLoop } from "../src/utils/agent/agent-loop.js";
+import type { AppConfig, McpServerConfig } from "../src/utils/config.js";
+import { McpClient } from "../src/utils/mcp-client.js";
+import { log } from "../src/utils/agent/log.js";
+import { vi, describe, test, expect, beforeEach, afterEach } from "vitest";
+import type OpenAI from "openai";
+
+// Mock the logger
+vi.mock("../src/utils/agent/log.js", () => ({
+  log: vi.fn(),
+}));
+
+// Mock OpenAI SDK
+const mockCreateChatCompletion = vi.fn();
+vi.mock("openai", () => ({
+  default: vi.fn(() => ({
+    chat: {
+      completions: {
+        create: mockCreateChatCompletion,
+      },
+    },
+  })),
+  APIConnectionTimeoutError: class extends Error { constructor(message?: string) { super(message); this.name = "APIConnectionTimeoutError";}},
+}));
+
+
+// Mock McpClient
+const mockMcpClientInstance = {
+  connect: vi.fn(),
+  listTools: vi.fn(),
+  callTool: vi.fn(),
+  disconnect: vi.fn(),
+  getIsConnected: vi.fn(),
+  getServerName: vi.fn(),
+};
+vi.mock("../src/utils/mcp-client.js", () => ({
+  McpClient: vi.fn(() => mockMcpClientInstance),
+}));
+
+// Mock handleExecCommand as it's called for shell tools and not the focus here
+vi.mock("../src/utils/agent/handle-exec-command.js", () => ({
+  handleExecCommand: vi.fn().mockResolvedValue({ outputText: "shell command executed", metadata: {} }),
+}));
+
+
+describe("AgentLoop with MCP Integration", () => {
+  let minimalAppConfig: AppConfig;
+  let mcpServerConfigs: McpServerConfig[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    minimalAppConfig = {
+      model: "test-model",
+      provider: "openai",
+      apiKey: "test-key",
+      instructions: "test-instructions",
+      mcpServers: [], // Default to empty, specific tests will override
+    };
+    
+    // Reset shared mock instance state for McpClient methods
+    mockMcpClientInstance.connect.mockReset();
+    mockMcpClientInstance.listTools.mockReset();
+    mockMcpClientInstance.callTool.mockReset();
+    mockMcpClientInstance.disconnect.mockReset();
+    mockMcpClientInstance.getIsConnected.mockReset();
+    mockMcpClientInstance.getServerName.mockReset();
+  });
+
+  test("Initialization: McpClient instances created and connect called for enabled servers", async () => {
+    mcpServerConfigs = [
+      { name: "Server1", url: "http://server1.com", enabled: true },
+      { name: "Server2", url: "http://server2.com" }, // enabled defaults to true
+    ];
+    minimalAppConfig.mcpServers = mcpServerConfigs;
+    
+    mockMcpClientInstance.connect.mockResolvedValue(undefined); // Mock connect to succeed
+
+    new AgentLoop({
+      model: minimalAppConfig.model,
+      config: minimalAppConfig,
+      approvalPolicy: "suggest",
+      onItem: vi.fn(),
+      onLoading: vi.fn(),
+      onReset: vi.fn(),
+      getCommandConfirmation: vi.fn(),
+      mcpServers: minimalAppConfig.mcpServers,
+    });
+
+    // Wait for async operations in constructor (initializeMcpClients)
+    await new Promise(process.nextTick);
+
+
+    expect(McpClient).toHaveBeenCalledTimes(2);
+    expect(McpClient).toHaveBeenCalledWith(mcpServerConfigs[0]);
+    expect(McpClient).toHaveBeenCalledWith(mcpServerConfigs[1]);
+    expect(mockMcpClientInstance.connect).toHaveBeenCalledTimes(2);
+  });
+
+  test("Initialization: No McpClient created for disabled servers", async () => {
+    mcpServerConfigs = [
+      { name: "Server1", url: "http://server1.com", enabled: false },
+      { name: "Server2", url: "http://server2.com", enabled: true },
+    ];
+    minimalAppConfig.mcpServers = mcpServerConfigs;
+    mockMcpClientInstance.connect.mockResolvedValue(undefined);
+
+
+    new AgentLoop({
+      model: minimalAppConfig.model,
+      config: minimalAppConfig,
+      approvalPolicy: "suggest",
+      onItem: vi.fn(),
+      onLoading: vi.fn(),
+      onReset: vi.fn(),
+      getCommandConfirmation: vi.fn(),
+      mcpServers: minimalAppConfig.mcpServers,
+    });
+    await new Promise(process.nextTick);
+
+
+    expect(McpClient).toHaveBeenCalledTimes(1);
+    expect(McpClient).toHaveBeenCalledWith(mcpServerConfigs[1]); // Only Server2
+    expect(mockMcpClientInstance.connect).toHaveBeenCalledTimes(1);
+  });
+
+  test("Initialization: Handles McpClient.connect failure", async () => {
+    mcpServerConfigs = [{ name: "FailServer", url: "http://fail.com", enabled: true }];
+    minimalAppConfig.mcpServers = mcpServerConfigs;
+    
+    const connectError = new Error("Connection failed");
+    // Ensure the mock is reset and then set to reject for this specific test
+    mockMcpClientInstance.connect.mockRejectedValueOnce(connectError);
+
+    new AgentLoop({
+      model: minimalAppConfig.model,
+      config: minimalAppConfig,
+      approvalPolicy: "suggest",
+      onItem: vi.fn(),
+      onLoading: vi.fn(),
+      onReset: vi.fn(),
+      getCommandConfirmation: vi.fn(),
+      mcpServers: minimalAppConfig.mcpServers,
+    });
+    await new Promise(process.nextTick);
+
+
+    expect(log).toHaveBeenCalledWith(`[AgentLoop] Failed to connect to MCP server FailServer: ${connectError.message}`);
+  });
+
+  test("getAvailableTools: Returns native and prefixed MCP tools", async () => {
+    mcpServerConfigs = [{ name: "MCPServer1", url: "http://mcp.com", enabled: true }];
+    minimalAppConfig.mcpServers = mcpServerConfigs;
+
+    // Mock behavior for the McpClient instance that will be created
+    mockMcpClientInstance.connect.mockResolvedValue(undefined);
+    mockMcpClientInstance.getIsConnected.mockReturnValue(true);
+    mockMcpClientInstance.listTools.mockResolvedValue([
+      { name: "mcpTool1", description: "Tool one from MCP", parameters: { type: "object", properties: {} } },
+    ]);
+
+    const agent = new AgentLoop({
+      model: minimalAppConfig.model,
+      config: minimalAppConfig,
+      approvalPolicy: "suggest",
+      onItem: vi.fn(),
+      onLoading: vi.fn(),
+      onReset: vi.fn(),
+      getCommandConfirmation: vi.fn(),
+      mcpServers: minimalAppConfig.mcpServers,
+    });
+    await new Promise(process.nextTick); // allow initializeMcpClients to complete
+
+
+    const tools = await agent.getAvailableTools();
+    expect(tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ function: expect.objectContaining({ name: "shell" }) }),
+        expect.objectContaining({
+          function: expect.objectContaining({ name: "mcp_MCPServer1_mcpTool1", description: "[MCP Tool@MCPServer1] Tool one from MCP" }),
+        }),
+      ])
+    );
+    expect(tools.length).toBe(2);
+  });
+  
+  const createMockChatCompletionMessageParam = (toolName: string, args: any, toolCallId: string = "call_123"): OpenAI.Chat.Completions.ChatCompletionMessageParam => {
+    return {
+      role: 'assistant',
+      tool_calls: [
+        {
+          id: toolCallId,
+          type: 'function',
+          function: {
+            name: toolName,
+            arguments: JSON.stringify(args),
+          },
+        },
+      ],
+    };
+  };
+
+  test("handleFunctionCall: MCP tool success", async () => {
+    mcpServerConfigs = [{ name: "S1", url: "http://s1.com", enabled: true }];
+    minimalAppConfig.mcpServers = mcpServerConfigs;
+
+    mockMcpClientInstance.connect.mockResolvedValue(undefined);
+    mockMcpClientInstance.getIsConnected.mockReturnValue(true);
+    mockMcpClientInstance.callTool.mockResolvedValue({ result: "mcp success" });
+
+    const agent = new AgentLoop({ /* params */ 
+        model: minimalAppConfig.model, config: minimalAppConfig, approvalPolicy: "suggest", 
+        onItem: vi.fn(), onLoading: vi.fn(), onReset: vi.fn(), getCommandConfirmation: vi.fn(),
+        mcpServers: minimalAppConfig.mcpServers
+    });
+    await new Promise(process.nextTick);
+
+    const toolCallItem = createMockChatCompletionMessageParam("mcp_S1_toolA", { arg: 1 });
+    const results = await agent["handleFunctionCall"](toolCallItem); // Accessing private method for test
+
+    expect(mockMcpClientInstance.callTool).toHaveBeenCalledWith("toolA", { arg: 1 });
+    expect(results[0].role).toBe("tool");
+    expect(results[0].tool_call_id).toBe("call_123");
+    expect(results[0].content).toBe(JSON.stringify({ result: "mcp success" }));
+  });
+
+  test("handleFunctionCall: MCP tool failure (callTool rejects)", async () => {
+    mcpServerConfigs = [{ name: "S1", url: "http://s1.com", enabled: true }];
+    minimalAppConfig.mcpServers = mcpServerConfigs;
+
+    mockMcpClientInstance.connect.mockResolvedValue(undefined);
+    mockMcpClientInstance.getIsConnected.mockReturnValue(true);
+    const callError = new Error("MCP call failed");
+    mockMcpClientInstance.callTool.mockRejectedValue(callError);
+
+    const agent = new AgentLoop({ /* params */
+        model: minimalAppConfig.model, config: minimalAppConfig, approvalPolicy: "suggest",
+        onItem: vi.fn(), onLoading: vi.fn(), onReset: vi.fn(), getCommandConfirmation: vi.fn(),
+        mcpServers: minimalAppConfig.mcpServers
+    });
+    await new Promise(process.nextTick);
+
+    const toolCallItem = createMockChatCompletionMessageParam("mcp_S1_toolB", {});
+    const results = await agent["handleFunctionCall"](toolCallItem);
+
+    expect(results[0].content).toBe(JSON.stringify({ error: `Failed to call MCP tool mcp_S1_toolB: ${callError.message}` }));
+  });
+
+  test("handleFunctionCall: MCP client not found or not connected", async () => {
+    mcpServerConfigs = [{ name: "S1", url: "http://s1.com", enabled: true }];
+    minimalAppConfig.mcpServers = mcpServerConfigs;
+
+    mockMcpClientInstance.connect.mockResolvedValue(undefined);
+    mockMcpClientInstance.getIsConnected.mockReturnValue(false); // Simulate not connected
+
+    const agent = new AgentLoop({ /* params */
+        model: minimalAppConfig.model, config: minimalAppConfig, approvalPolicy: "suggest",
+        onItem: vi.fn(), onLoading: vi.fn(), onReset: vi.fn(), getCommandConfirmation: vi.fn(),
+        mcpServers: minimalAppConfig.mcpServers
+     });
+    await new Promise(process.nextTick);
+
+    const toolCallItem = createMockChatCompletionMessageParam("mcp_S1_toolC", {});
+    const results = await agent["handleFunctionCall"](toolCallItem);
+    expect(results[0].content).toBe(JSON.stringify({ error: "MCP client S1 not found or not connected." }));
+
+    const toolCallItemNonExistent = createMockChatCompletionMessageParam("mcp_S2_toolD", {});
+    const resultsNonExistent = await agent["handleFunctionCall"](toolCallItemNonExistent);
+    expect(resultsNonExistent[0].content).toBe(JSON.stringify({ error: "MCP client S2 not found or not connected." }));
+  });
+  
+  test("handleFunctionCall: Native shell tool", async () => {
+    const agent = new AgentLoop({ /* params - no mcpServers needed for this test */
+        model: minimalAppConfig.model, config: minimalAppConfig, approvalPolicy: "suggest",
+        onItem: vi.fn(), onLoading: vi.fn(), onReset: vi.fn(), getCommandConfirmation: vi.fn(),
+        mcpServers: []
+    });
+    await new Promise(process.nextTick);
+
+    const shellCommandArgs = { command: ["ls", "-l"] };
+    const toolCallItem = createMockChatCompletionMessageParam("shell", shellCommandArgs);
+    
+    // We mocked handleExecCommand, so we expect it to be called.
+    await agent["handleFunctionCall"](toolCallItem);
+
+    expect(require("../src/utils/agent/handle-exec-command.js").handleExecCommand).toHaveBeenCalledWith(
+      shellCommandArgs,
+      expect.any(Object), // appConfig
+      "suggest",          // approvalPolicy
+      expect.any(Function), // getCommandConfirmation
+      expect.anything()   // abortSignal
+    );
+    expect(mockMcpClientInstance.callTool).not.toHaveBeenCalled();
+  });
+
+  test("terminate: Disconnects all active McpClient instances", async () => {
+    mcpServerConfigs = [
+        { name: "Server1", url: "http://s1.com", enabled: true },
+        { name: "Server2", url: "http://s2.com", enabled: true }
+    ];
+    minimalAppConfig.mcpServers = mcpServerConfigs;
+
+    // For this test, we need McpClient constructor to be called multiple times
+    // and each instance's disconnect to be tracked.
+    // This requires a more sophisticated mock for McpClient itself.
+    // However, with the current shared mockMcpClientInstance, we can only check if disconnect was called.
+    // To properly test multiple instances, the mock setup for McpClient would need to change.
+    // For now, we'll assert disconnect is called (implicitly, on the shared mock).
+    
+    mockMcpClientInstance.connect.mockResolvedValue(undefined);
+    mockMcpClientInstance.getIsConnected.mockReturnValue(true); // Assume they all connected
+    mockMcpClientInstance.getServerName.mockImplementation(() => "mockedServerName"); // Provide implementation
+
+    const agent = new AgentLoop({ /* params */
+        model: minimalAppConfig.model, config: minimalAppConfig, approvalPolicy: "suggest",
+        onItem: vi.fn(), onLoading: vi.fn(), onReset: vi.fn(), getCommandConfirmation: vi.fn(),
+        mcpServers: minimalAppConfig.mcpServers
+    });
+    await new Promise(process.nextTick); // For initializeMcpClients
+
+    agent.terminate();
+    await new Promise(process.nextTick); // For async operations in terminate
+
+    // Since McpClient is mocked to return a single shared instance (mockMcpClientInstance),
+    // we expect disconnect to have been called on that instance.
+    // In a real scenario with multiple instances, you'd check disconnect on each.
+    // Number of calls to McpClient constructor indicates how many "instances" were notionally created.
+    const numClientsInitialized = (McpClient as ReturnType<typeof vi.fn>).mock.calls.length;
+    if (numClientsInitialized > 0) {
+        expect(mockMcpClientInstance.disconnect).toHaveBeenCalledTimes(numClientsInitialized);
+    } else {
+        // if no clients were initialized (e.g. all disabled), disconnect shouldn't be called.
+        expect(mockMcpClientInstance.disconnect).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/codex-cli/tests/mcp-client.test.ts
+++ b/codex-cli/tests/mcp-client.test.ts
@@ -1,0 +1,203 @@
+import { McpClient } from "../src/utils/mcp-client.js";
+import type { McpServerConfig } from "../src/utils/config.js";
+import { log } from "../src/utils/agent/log.js";
+import { vi, describe, test, expect, beforeEach, afterEach } from "vitest";
+
+// Mock the logger
+vi.mock("../src/utils/agent/log.js", () => ({
+  log: vi.fn(),
+}));
+
+// Mock the SDK
+const mockSdkClient = {
+  connect: vi.fn(),
+  listTools: vi.fn(),
+  callTool: vi.fn(),
+  disconnect: vi.fn(),
+  on: vi.fn(), // Mock the 'on' event emitter method
+};
+const mockStreamableHTTPClientTransport = vi.fn();
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn(() => mockSdkClient),
+  StreamableHTTPClientTransport: mockStreamableHTTPClientTransport,
+}));
+
+describe("McpClient", () => {
+  let serverConfig: McpServerConfig;
+
+  beforeEach(() => {
+    serverConfig = {
+      name: "TestServer",
+      url: "http://localhost:1234",
+      enabled: true,
+    };
+    // Reset all mocks before each test
+    vi.clearAllMocks();
+  });
+
+  test("constructor does not initialize SDK client or transport immediately (lazy initialization)", () => {
+    new McpClient(serverConfig);
+    expect(mockStreamableHTTPClientTransport).not.toHaveBeenCalled();
+    expect(mockSdkClient.connect).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(`[McpClient] Initializing for server: ${serverConfig.name} at ${serverConfig.url}`);
+  });
+
+  test("connect successfully initializes and connects the SDK client", async () => {
+    const client = new McpClient(serverConfig);
+    mockSdkClient.connect.mockResolvedValue(undefined);
+
+    await client.connect();
+
+    expect(mockStreamableHTTPClientTransport).toHaveBeenCalledWith(new URL(serverConfig.url));
+    expect(log).toHaveBeenCalledWith(`[McpClient] Lazily initializing transport and client for ${serverConfig.name}`);
+    expect(log).toHaveBeenCalledWith(`[McpClient] Client and transport initialized for ${serverConfig.name}.`);
+    expect(mockSdkClient.connect).toHaveBeenCalledWith(mockStreamableHTTPClientTransport.mock.instances[0]);
+    expect(client.getIsConnected()).toBe(true);
+    expect(log).toHaveBeenCalledWith(`[McpClient] Successfully connected to ${serverConfig.name}.`);
+  });
+  
+  test("connect throws if server URL is not defined", async () => {
+    const client = new McpClient({ name: "NoUrlServer" } as McpServerConfig); // URL is undefined
+    await expect(client.connect()).rejects.toThrow("Server URL is not defined for NoUrlServer. Cannot initialize client.");
+    expect(log).toHaveBeenCalledWith("[McpClient] Server URL is not defined for NoUrlServer. Cannot initialize client.");
+    expect(client.getIsConnected()).toBe(false);
+  });
+
+  test("connect throws if SDK client.connect rejects", async () => {
+    const client = new McpClient(serverConfig);
+    const connectError = new Error("SDK connection failed");
+    mockSdkClient.connect.mockRejectedValue(connectError);
+
+    await expect(client.connect()).rejects.toThrow(connectError);
+    expect(client.getIsConnected()).toBe(false);
+    expect(log).toHaveBeenCalledWith(`[McpClient] Failed to connect to ${serverConfig.name}: ${connectError.message}`);
+  });
+
+  test("connect throws if URL is invalid", async () => {
+    const invalidServerConfig = { ...serverConfig, url: "invalid-url" };
+    const client = new McpClient(invalidServerConfig);
+
+    await expect(client.connect()).rejects.toThrow(); // Specific error message depends on URL constructor
+    expect(client.getIsConnected()).toBe(false);
+    // Check that log contains message about lazy initialization failure
+    expect(log).toHaveBeenCalledWith(expect.stringContaining(`[McpClient] Error during lazy initialization for ${invalidServerConfig.name}`));
+  });
+  
+  test("listTools successfully retrieves tools after connection", async () => {
+    const client = new McpClient(serverConfig);
+    await client.connect(); // Ensure connected
+
+    const mockTools = [{ name: "tool1", description: "A test tool" }];
+    mockSdkClient.listTools.mockResolvedValue(mockTools);
+
+    const tools = await client.listTools();
+
+    expect(mockSdkClient.listTools).toHaveBeenCalled();
+    expect(tools).toEqual(mockTools);
+    expect(log).toHaveBeenCalledWith(`[McpClient] Found ${mockTools.length} tools on ${serverConfig.name}.`);
+  });
+
+  test("listTools throws if not connected", async () => {
+    const client = new McpClient(serverConfig);
+    await expect(client.listTools()).rejects.toThrow("Not connected to TestServer. Call connect() first.");
+  });
+
+  test("listTools throws if SDK client.listTools rejects", async () => {
+    const client = new McpClient(serverConfig);
+    await client.connect(); 
+
+    const listToolsError = new Error("SDK listTools failed");
+    mockSdkClient.listTools.mockRejectedValue(listToolsError);
+
+    await expect(client.listTools()).rejects.toThrow(listToolsError);
+    expect(log).toHaveBeenCalledWith(`[McpClient] Failed to list tools from ${serverConfig.name}: ${listToolsError.message}`);
+  });
+
+  test("callTool successfully calls a tool after connection", async () => {
+    const client = new McpClient(serverConfig);
+    await client.connect();
+
+    const toolName = "myTool";
+    const toolArgs = { param1: "value1" };
+    const mockResult = { success: true, data: "tool output" };
+    mockSdkClient.callTool.mockResolvedValue(mockResult);
+
+    const result = await client.callTool(toolName, toolArgs);
+
+    expect(mockSdkClient.callTool).toHaveBeenCalledWith({ name: toolName, arguments: toolArgs });
+    expect(result).toEqual(mockResult);
+    expect(log).toHaveBeenCalledWith(`[McpClient] Tool "${toolName}" on ${serverConfig.name} executed successfully.`);
+  });
+
+  test("callTool throws if not connected", async () => {
+    const client = new McpClient(serverConfig);
+    await expect(client.callTool("test", {})).rejects.toThrow("Not connected to TestServer. Call connect() first.");
+  });
+
+  test("callTool throws if SDK client.callTool rejects", async () => {
+    const client = new McpClient(serverConfig);
+    await client.connect();
+
+    const callToolError = new Error("SDK callTool failed");
+    mockSdkClient.callTool.mockRejectedValue(callToolError);
+    const toolName = "errorTool";
+
+    await expect(client.callTool(toolName, {})).rejects.toThrow(callToolError);
+    expect(log).toHaveBeenCalledWith(`[McpClient] Failed to call tool "${toolName}" on ${serverConfig.name}: ${callToolError.message}`);
+  });
+  
+  test("disconnect successfully disconnects the SDK client", async () => {
+    const client = new McpClient(serverConfig);
+    await client.connect(); // Connect first
+
+    mockSdkClient.disconnect.mockResolvedValue(undefined);
+    await client.disconnect();
+
+    expect(mockSdkClient.disconnect).toHaveBeenCalled();
+    expect(client.getIsConnected()).toBe(false);
+    expect(log).toHaveBeenCalledWith(`[McpClient] Successfully disconnected from ${serverConfig.name}.`);
+  });
+
+  test("disconnect does nothing if already disconnected (and client not initialized)", async () => {
+    const client = new McpClient(serverConfig);
+    // Ensure client is not initialized by not calling connect
+    await client.disconnect(); // Attempt disconnect
+    
+    expect(mockSdkClient.disconnect).not.toHaveBeenCalled(); // Should not be called if client was never initialized fully
+    expect(client.getIsConnected()).toBe(false);
+    expect(log).toHaveBeenCalledWith(`[McpClient] Client for ${serverConfig.name} was not initialized. Nothing to disconnect.`);
+  });
+
+  test("disconnect does nothing if called multiple times after successful disconnect", async () => {
+    const client = new McpClient(serverConfig);
+    await client.connect();
+    await client.disconnect(); // First disconnect
+    
+    mockSdkClient.disconnect.mockClear(); // Clear previous call count
+    
+    await client.disconnect(); // Second disconnect
+    
+    expect(mockSdkClient.disconnect).not.toHaveBeenCalled(); // Should not be called again
+    expect(client.getIsConnected()).toBe(false);
+    expect(log).toHaveBeenCalledWith(`[McpClient] Already disconnected from ${serverConfig.name}.`);
+  });
+  
+  test("SDK client 'error' event sets isConnected to false", async () => {
+    const client = new McpClient(serverConfig);
+    await client.connect();
+    expect(client.getIsConnected()).toBe(true);
+
+    // Simulate the 'error' event being emitted by the SDK client
+    // The mockSdkClient.on.mock.calls[0][1] should be the error handler function
+    const errorHandler = mockSdkClient.on.mock.calls.find(call => call[0] === 'error')?.[1];
+    expect(errorHandler).toBeDefined();
+
+    if (errorHandler) {
+      const testError = new Error("Simulated SDK connection error");
+      errorHandler(testError); // Call the error handler
+      expect(log).toHaveBeenCalledWith(`[McpClient] Connection error on ${serverConfig.name}: ${testError.message}`);
+      expect(client.getIsConnected()).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
This commit introduces the capability to configure and use tools from external Model Context Protocol (MCP) servers.

Key changes:

-   **Configuration:** You can now define MCP servers in your
    `~/.codex/config.yaml` or `config.json` file under the `mcpServers`
    key. Each server configuration includes a name, URL, an optional
    `enabled` flag, and an optional `auth` object for future use.
-   **MCP Client:** A new `McpClient` (`codex-cli/src/utils/mcp-client.ts`)
    has been implemented using the `@modelcontextprotocol/sdk`. This client
    handles connection, tool listing, and tool execution for configured
    MCP servers.
-   **Agent Integration:** My core logic now
    initializes and manages `McpClient` instances. I dynamically
    discover tools from connected MCP servers and make them available. MCP tools are prefixed with `mcp_<serverName>_` to
    distinguish them. I route calls to these tools to the
    appropriate MCP server.
-   **Testing:** Comprehensive unit tests have been added for:
    -   Loading MCP server configurations.
    -   The `McpClient` functionality (mocking the SDK).
    -   My integration with MCP clients, including
        tool discovery and execution.
-   **Documentation:** The `README.md` has been updated to include a
    new section explaining how to configure and use MCP servers.

This integration allows you to extend my capabilities by connecting me to any MCP-compliant tool provider, opening up a wide range of potential new functionalities.